### PR TITLE
Detect firefox from any folder in path

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -213,9 +213,10 @@ async function findFirefoxExecutable(configuredPath?: string): Promise<string> {
 		case 'linux':
 		case 'freebsd':
 		case 'sunos':
+			const paths = process.env.PATH.split(':');
 			candidates = [
-				'/usr/bin/firefox-developer',
-				'/usr/bin/firefox'
+				...paths.map(dir => path.join(dir, 'firefox-developer')),
+				...paths.map(dir => path.join(dir, 'firefox')),
 			]
 			break;
 


### PR DESCRIPTION
Firefox developer edition can be installed anywhere, and more likely in `/usr/local` or `~/.local` or maybe in `/opt`. It's for the user to decide.

A reasonable approach would be to probe each of the directories under `PATH` for `firefox-developer` and `firefox`.

The motivation of this patch comes from the requirement of managing VS Code and Firefox Dev installations for a slightly less UNIX familiar audience. The tool - [umake](https://wiki.ubuntu.com/ubuntu-make), that we use, puts the binaries under `~/.local/bin`. 